### PR TITLE
Switch from py38 to py311

### DIFF
--- a/config/asv.conf.json
+++ b/config/asv.conf.json
@@ -20,7 +20,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.11"],
+    "pythons": ["3.8", "3.11"],
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty
     // list indicates to just test against the default (latest)

--- a/config/asv.conf.json
+++ b/config/asv.conf.json
@@ -20,7 +20,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.8"],
+    "pythons": ["3.11"],
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty
     // list indicates to just test against the default (latest)

--- a/config/asv_c3potato.conf.json
+++ b/config/asv_c3potato.conf.json
@@ -21,7 +21,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.8"],
+    "pythons": ["3.11"],
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty
     // list indicates to just test against the default (latest)

--- a/config/asv_c3potato.conf.json
+++ b/config/asv_c3potato.conf.json
@@ -21,7 +21,7 @@
 
     // The Pythons you'd like to test against.  If not provided, defaults
     // to the current version of Python used to run `asv`.
-    "pythons": ["3.11"],
+    "pythons": ["3.8", "3.11"],
     // The matrix of dependencies to test.  Each key is the name of a
     // package (in PyPI) and the values are version numbers.  An empty
     // list indicates to just test against the default (latest)

--- a/scripts/cron.sh
+++ b/scripts/cron.sh
@@ -71,7 +71,8 @@ asv run -e --config ${ASV_CONFIG} NEW || true
 ## For Python 2.7: start at release-0.11.0
 ## For Python 3.6: start at release-0.17.0
 ## For Python 3.8: start at release-1.0.1
-timeout ${TIMEOUT} asv run -e -j 4 --config ${ASV_CONFIG} "release-1.0.1..HEAD --merges" --skip-existing || true
+## For Python 3.11: start at release-2.4.0
+timeout ${TIMEOUT} asv run -e -j 4 --config ${ASV_CONFIG} "release-2.4.0..HEAD --merges" --skip-existing || true
 
 # We split the benchmarks from the results benchmarks are with the main code,
 # results are in separate repo.


### PR DESCRIPTION
So I went with a full switch here, but my understanding is that we could also just have both py38 and py311 running alongside each other since they can take in a list? Not sure if that's an option that we want to go for instead?